### PR TITLE
Validate validator schema with schemas definitions

### DIFF
--- a/schemavalidator/__init__.py
+++ b/schemavalidator/__init__.py
@@ -1,2 +1,4 @@
-from schemavalidator.schemavalidator import SchemaValidator, SchemaValidatorError, SchemaValidationError,\
-    SchemaError, UnkownSchemaError
+from schemavalidator.schemavalidator import SchemaValidator,\
+    SchemaValidatorError, SchemaValidationError, SchemaError,\
+    UnkownSchemaError, SchemaOpenError, SchemaJSONError, SchemaKeyError,\
+    SchemaValidError, SchemaStrictnessError

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -5,8 +5,7 @@ try:
     from json import JSONDecodeError
 except:
     # json in python < 3.5 has no JSONDecodeError
-    class JSONDecodeError(ValueError):
-        pass
+    JSONDecodeError = ValueError
 
 import os
 

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -1,4 +1,13 @@
 import json
+
+# Hack to be compatible with json in python < 3.5
+try:
+    from json import JSONDecodeError
+except:
+    # json in python < 3.5 has no JSONDecodeError
+    class JSONDecodeError(TypeError):
+        pass
+
 import os
 
 import jsonschema
@@ -91,7 +100,7 @@ class SchemaValidator(object):
                     self.schemas[schema['id']] = schema
             except OSError as e:
                 raise SchemaOpenError(e, schema_file_name) from e
-            except json.JSONDecodeError as e:
+            except JSONDecodeError as e:
                 raise SchemaJSONError(e, schema_file_name) from e
             except jsonschema.exceptions.SchemaError as e:
                 raise SchemaValidError(e, schema_file_name) from e

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -5,7 +5,7 @@ try:
     from json import JSONDecodeError
 except:
     # json in python < 3.5 has no JSONDecodeError
-    class JSONDecodeError(TypeError):
+    class JSONDecodeError(ValueError):
         pass
 
 import os

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-import requests
 import jsonschema
 from jsonschema.exceptions import ValidationError
+import requests
 
 
 class SchemaValidatorError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 setup(
     name='schemavalidator',
     packages=['schemavalidator'],
-    version='0.1.0b1',
+    version='0.1.0b2',
     description='A local JSON schema validator based on jsonschema',
     author='Daan Porru (Wend)',
     author_email='daan@wend.nl',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     ],
     install_requires=['jsonschema', 'requests'],
     extras_require={
-        'test': ['pytest', 'pytest-cov', 'coverage', 'coveralls'],
+        'test': ['pytest', 'pytest-cov', 'coverage', 'coveralls',
+                 'pytest-mock'],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3',
     ],
-    install_requires=['jsonschema'],
+    install_requires=['jsonschema', 'requests'],
     extras_require={
         'test': ['pytest', 'pytest-cov', 'coverage', 'coveralls'],
     }

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import jsonschema
 import pytest
 
@@ -13,6 +14,13 @@ def raise_exception(*args, **kwargs):
 @pytest.fixture
 def schema_validator(monkeypatch):
     monkeypatch.setattr(SchemaValidator, 'load_schemas', lambda self, p: None)
+    monkeypatch.setattr(SchemaValidator, '_load_strictness_schema',
+                        lambda self, p: None)
+
+    Validator = namedtuple('Validator', ['validate'])
+    strictness = Validator(lambda x: None)
+    SchemaValidator.strictness_validator = strictness
+
     return SchemaValidator()
 
 

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+
 import jsonschema
 import pytest
 


### PR DESCRIPTION
That's not confusing!

This PR adds a single step of using a JSON Schema that defines JSON Schema schemas to validate the schemas you're trying to validate documents with.
