### PR TITLE
Add support for schemas in sub directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "3.3"
-  - "3.4"
   - "3.5"
 # command to install dependencies
 install: "pip install -e '.[test]'"

--- a/schemas/test.json
+++ b/schemas/test.json
@@ -1,0 +1,11 @@
+{
+    "id": "test.json",
+    "type": "object",
+
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "date": { "$ref": "types/date.json" }
+    }
+}

--- a/schemas/types/date.json
+++ b/schemas/types/date.json
@@ -1,0 +1,7 @@
+{
+    "id": "types/date.json",
+    "title": "ISO Date",
+    "description": "ISO 8601 date format.",
+    "type": "string",
+    "pattern": "\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d(\\.\\d+)?([+-][0-2]\\d:[0-5]\\d|Z)?"
+}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 setup(
     name='schemavalidator',
     packages=['schemavalidator'],
-    version='0.1.0b2',
+    version='0.1.0b3',
     description='A local JSON schema validator based on jsonschema',
     author='Daan Porru (Wend)',
     author_email='daan@wend.nl',
@@ -13,7 +13,7 @@ setup(
     keywords=['json schema', 'validator'],
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
     ],
     install_requires=['jsonschema', 'requests'],
     extras_require={


### PR DESCRIPTION
- Schemas in directories that are children of the `schema_base_path`
  directory are now also found and parsed. You can use `"$ref":
  "subdir/schema.json"` to refer to these schemas.
- `id` field value now has to be identical to file_name, as we're now
  indexing the schemas by `[subdir/]file_name` instead of `id`.
- Dropping support for `Python 3.4`. So we can use the recursive feature
  of `glob`.
- Bump version to 0.1.0b3
