### PR TITLE
Add validate_string function.

### DIFF
--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -130,6 +130,9 @@ class SchemaValidator(object):
         except ValidationError as e:
             raise SchemaValidationError(e.message) from e
 
+    def validate_string(self, document, schema_id):
+        return self.validate(json.loads(document), schema_id)
+
     def get_schema_files(self, schema_base_path):
         files = glob('{}/**/*.json'.format(schema_base_path), recursive=True)
 

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -130,8 +130,8 @@ class SchemaValidator(object):
         except ValidationError as e:
             raise SchemaValidationError(e.message) from e
 
-    def validate_json_string(self, document, schema_id):
-        return self.validate(json.loads(document), schema_id)
+    def validate_json_string(self, json_string, schema_id):
+        return self.validate(json.loads(json_string), schema_id)
 
     def get_schema_files(self, schema_base_path):
         files = glob('{}/**/*.json'.format(schema_base_path), recursive=True)

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -130,7 +130,7 @@ class SchemaValidator(object):
         except ValidationError as e:
             raise SchemaValidationError(e.message) from e
 
-    def validate_string(self, document, schema_id):
+    def validate_json_string(self, document, schema_id):
         return self.validate(json.loads(document), schema_id)
 
     def get_schema_files(self, schema_base_path):

--- a/tests.py
+++ b/tests.py
@@ -187,13 +187,12 @@ def test_validate_validate_exception(monkeypatch, schema_validator):
     schema_validator.validate({}, '/test.json')
 
 
-def test_validate_validate_string(monkeypatch, schema_validator, mocker):
+def test_validate_validate_string(schema_validator, mocker):
     mocker.patch.object(schema_validator, 'get_schema', return_value={})
     mocker.patch.object(Resolver, '__init__', return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, '__init__',
                         return_value=None)
-    mocker.patch.object(jsonschema.Draft4Validator, 'validate',
-                        return_value=None)
+    mocker.patch.object(jsonschema.Draft4Validator, 'validate')
 
     schema_validator.validate_json_string('{}', '/test.json')
 
@@ -204,7 +203,6 @@ def test_validate_validate_string_exception(schema_validator, mocker):
     mocker.patch.object(jsonschema.Draft4Validator, '__init__',
                         return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, 'validate',
-                        return_value=None,
                         side_effect=jsonschema.exceptions.ValidationError(""))
 
     with pytest.raises(SchemaValidatorError):

--- a/tests.py
+++ b/tests.py
@@ -195,7 +195,7 @@ def test_validate_validate_string(monkeypatch, schema_validator, mocker):
     mocker.patch.object(jsonschema.Draft4Validator, 'validate',
                         return_value=None)
 
-    schema_validator.validate_string('{}', '/test.json')
+    schema_validator.validate_json_string('{}', '/test.json')
 
 
 def test_validate_validate_string_exception(schema_validator, mocker):
@@ -208,7 +208,7 @@ def test_validate_validate_string_exception(schema_validator, mocker):
                         side_effect=jsonschema.exceptions.ValidationError(""))
 
     with pytest.raises(SchemaValidatorError):
-        schema_validator.validate_string('{}', '/test.json')
+        schema_validator.validate_json_string('{}', '/test.json')
 
 def test_get_schema_files(schema_validator, tmpdir):
     tmpdir.join('test.json').write('')

--- a/tests.py
+++ b/tests.py
@@ -187,19 +187,18 @@ def test_validate_validate_exception(monkeypatch, schema_validator):
     schema_validator.validate({}, '/test.json')
 
 
-def test_validate_validate_string(schema_validator, mocker):
+def test_validate_validate_json_string(schema_validator, mocker):
+    mocker.patch("jsonschema.Draft4Validator")
     mocker.patch.object(schema_validator, 'get_schema', return_value={})
     mocker.patch.object(Resolver, '__init__', return_value=None)
-    mocker.patch.object(jsonschema.Draft4Validator, '__init__',
-                        return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, 'validate')
 
     schema_validator.validate_json_string('{}', '/test.json')
 
 
-def test_validate_validate_string_exception(schema_validator, mocker):
+def test_validate_validate_json_string_exception(schema_validator, mocker):
+    mocker.patch('schemavalidator.schemavalidator.Resolver')
     mocker.patch.object(schema_validator, 'get_schema', return_value={})
-    mocker.patch.object(Resolver, '__init__', return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, '__init__',
                         return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, 'validate',

--- a/tests.py
+++ b/tests.py
@@ -187,6 +187,29 @@ def test_validate_validate_exception(monkeypatch, schema_validator):
     schema_validator.validate({}, '/test.json')
 
 
+def test_validate_validate_string(monkeypatch, schema_validator, mocker):
+    mocker.patch.object(schema_validator, 'get_schema', return_value={})
+    mocker.patch.object(Resolver, '__init__', return_value=None)
+    mocker.patch.object(jsonschema.Draft4Validator, '__init__',
+                        return_value=None)
+    mocker.patch.object(jsonschema.Draft4Validator, 'validate',
+                        return_value=None)
+
+    schema_validator.validate_string('{}', '/test.json')
+
+
+def test_validate_validate_string_exception(schema_validator, mocker):
+    mocker.patch.object(schema_validator, 'get_schema', return_value={})
+    mocker.patch.object(Resolver, '__init__', return_value=None)
+    mocker.patch.object(jsonschema.Draft4Validator, '__init__',
+                        return_value=None)
+    mocker.patch.object(jsonschema.Draft4Validator, 'validate',
+                        return_value=None,
+                        side_effect=jsonschema.exceptions.ValidationError(""))
+
+    with pytest.raises(SchemaValidatorError):
+        schema_validator.validate_string('{}', '/test.json')
+
 def test_get_schema_files(schema_validator, tmpdir):
     tmpdir.join('test.json').write('')
     tmpdir.join('test.jpg').write('')

--- a/tests.py
+++ b/tests.py
@@ -190,7 +190,6 @@ def test_validate_validate_exception(monkeypatch, schema_validator):
 def test_validate_validate_json_string(schema_validator, mocker):
     mocker.patch("jsonschema.Draft4Validator")
     mocker.patch.object(schema_validator, 'get_schema', return_value={})
-    mocker.patch.object(Resolver, '__init__', return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, 'validate')
 
     schema_validator.validate_json_string('{}', '/test.json')
@@ -199,8 +198,6 @@ def test_validate_validate_json_string(schema_validator, mocker):
 def test_validate_validate_json_string_exception(schema_validator, mocker):
     mocker.patch('schemavalidator.schemavalidator.Resolver')
     mocker.patch.object(schema_validator, 'get_schema', return_value={})
-    mocker.patch.object(jsonschema.Draft4Validator, '__init__',
-                        return_value=None)
     mocker.patch.object(jsonschema.Draft4Validator, 'validate',
                         side_effect=jsonschema.exceptions.ValidationError(""))
 


### PR DESCRIPTION
This will allow some code cleanup in cases where you use a custom json serializer. instead of having `validate(json.loads(json.dumps(something)))` you can now write `validate_string(json.dumps(something))`.
