### PR TITLE
Add verbose logging on ValidationError

### DIFF
--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -4,12 +4,14 @@ import json
 from json import JSONDecodeError
 
 import os
+import logging
 
 import jsonschema
 from jsonschema.exceptions import ValidationError
 import requests
+from .util import format_error_table
 
-from .util import log_error_table
+logger = logging.getLogger(__name__)
 
 
 class SchemaValidatorError(Exception):
@@ -130,7 +132,7 @@ class SchemaValidator(object):
         try:
             validator.validate(document, schema)
         except ValidationError as e:
-            log_error_table(validator,document,schema)
+            logger.debug(format_error_table(validator, document, schema))
             raise SchemaValidationError(e.message) from e
 
     def validate_json_string(self, json_string, schema_id):

--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -4,11 +4,13 @@ import json
 from json import JSONDecodeError
 
 import os
+import logging
 
 import jsonschema
 from jsonschema.exceptions import ValidationError
 import requests
 
+logger = logging.getLogger(__name__)
 
 class SchemaValidatorError(Exception):
     """Base Exception for the schemavalidator module."""
@@ -128,6 +130,44 @@ class SchemaValidator(object):
         try:
             validator.validate(document, schema)
         except ValidationError as e:
+            errors = []
+            todo = list(validator.iter_errors(document, schema))
+            while todo:
+                error = todo.pop()
+                errors.append((list(error.absolute_schema_path),
+                               list(error.absolute_path), error.message))
+                todo.extend(error.context)
+            errors.sort()
+            table = []
+            for error in errors:
+                schema_path, path, message = error
+                if len(path) == 0:
+                    path = "$"
+                else:
+                    path = "$["+']['.join((repr(x) for x in path))+"]"
+                if len(schema_path) == 0:
+                    schema_path = "schema"
+                else:
+                    schema_path = "schema[" + ']['.join(
+                        (repr(x) for x in schema_path)) + "]"
+
+                table.append([schema_path, path, message])
+            if len(table) > 0:
+                headings = ['schema path', 'instance path', 'message']
+                widths = [len(max(list(col)+[headings[i]],
+                              key=lambda v:len(v)))
+                          for i, col in enumerate(zip(*table))]
+                logger.info('╔═'+'═╤═'.join(['═'*w for w in widths])+'═╗')
+                logger.info('║ '+' │ '.join([
+                    h.center(widths[i]) for i, h in enumerate(headings)
+                ])+' ║')
+                logger.info('╠═'+'═╪═'.join(['═'*w for w in widths])+'═╣')
+                for row in table:
+                    row_padded = []
+                    for i, column in enumerate(row):
+                        row_padded.append(column.ljust(widths[i]))
+                    logger.info('║ '+' │ '.join(row_padded)+' ║')
+                logger.info('╚═'+'═╧═'.join(['═'*w for w in widths])+'═╝')
             raise SchemaValidationError(e.message) from e
 
     def validate_json_string(self, json_string, schema_id):

--- a/schemavalidator/util.py
+++ b/schemavalidator/util.py
@@ -1,14 +1,10 @@
-import logging
-
-logger = logging.getLogger(__name__)
-
-
-def log_error_table(validator, document, schema, level=logging.DEBUG):
+def format_error_table(validator, document, schema):
     errors = collect_errors(validator, document, schema)
     table = errors_to_table(errors)
     if len(table) > 0:
-        logger.log(level, format_table(table, ['schema path', 'instance path',
-                                               'message']))
+        return format_table(table, ['schema path', 'instance path', 'message'])
+    else:
+        return "No additional info available."
 
 
 def errors_to_table(errors):

--- a/schemavalidator/util.py
+++ b/schemavalidator/util.py
@@ -1,0 +1,58 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def log_error_table(validator, document, schema, level=logging.DEBUG):
+    errors = collect_errors(validator, document, schema)
+    table = errors_to_table(errors)
+    if len(table) > 0:
+        logger.log(level, format_table(table, ['schema path', 'instance path',
+                                               'message']))
+
+
+def errors_to_table(errors):
+    table = []
+    for error in errors:
+        path = format_path(error.absolute_path)
+        schema_path = format_path(error.absolute_schema_path, "schema")
+
+        table.append([schema_path, path, error.message])
+    return table
+
+
+def format_path(path, prefix="$"):
+    if len(path) == 0:
+        return prefix
+    return "{}[{}]".format(prefix, ']['.join((repr(x) for x in path)))
+
+
+def collect_errors(validator, document, schema):
+    todo = list(validator.iter_errors(document, schema))
+    errors = []
+    while todo:
+        error = todo.pop()
+        errors.append(error)
+        todo.extend(error.context)
+    errors.sort(key=lambda e: e.absolute_schema_path)
+    return errors
+
+
+def format_table(table, headings):
+    outlines = ['']
+    widths = [len(max(list(col) + [headings[i]],
+              key=lambda v: len(v)))
+              for i, col in enumerate(zip(*table))]
+
+    outlines.append('╔═' + '═╤═'.join(['═' * w for w in widths]) + '═╗')
+    outlines.append('║ ' + ' │ '.join([
+        h.center(widths[i]) for i, h in enumerate(headings)
+        ]) + ' ║')
+    outlines.append('╠═' + '═╪═'.join(['═' * w for w in widths]) + '═╣')
+    for row in table:
+        row_padded = []
+        for i, column in enumerate(row):
+            row_padded.append(column.ljust(widths[i]))
+        outlines.append('║ ' + ' │ '.join(row_padded) + ' ║')
+    outlines.append('╚═' + '═╧═'.join(['═' * w for w in widths]) + '═╝')
+    return '\n'.join(outlines)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     install_requires=['jsonschema', 'requests'],
     extras_require={
         'test': ['pytest', 'pytest-cov', 'coverage', 'coveralls',
-                 'pytest-mock'],
+                 'pytest-mock', 'mock'],
     }
 )

--- a/tests.py
+++ b/tests.py
@@ -1,16 +1,22 @@
 from collections import namedtuple
+import logging
+import sys
 
 import jsonschema
 import requests
 import pytest
+import mock
 
 from schemavalidator import SchemaValidator, UnkownSchemaError,\
     SchemaValidatorError, SchemaValidationError, SchemaOpenError,\
     SchemaJSONError, SchemaKeyError, SchemaValidError, SchemaStrictnessError
 from schemavalidator.schemavalidator import Resolver
+from jsonschema.exceptions import ValidationError
 
 # Validator mock
 Validator = namedtuple('Validator', ['validate'])
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 def raise_exception(*args, **kwargs):
@@ -27,6 +33,41 @@ def schema_validator(monkeypatch):
     SchemaValidator.strictness_validator = strictness
 
     return SchemaValidator()
+
+def test_validation_error_log(mocker, tmpdir):
+    mocker.patch.object(SchemaValidator, 'load_schemas')
+    mocker.patch.object(SchemaValidator, '_load_strictness_schema')
+    mocker.patch.object(SchemaValidator, 'get_schema',
+                        mocker.Mock(return_value={}))
+    logger=mocker.patch('schemavalidator.schemavalidator.logger',
+                        info=mocker.Mock())
+    validator_mock=mocker.Mock(
+        validate=mocker.Mock(side_effect=ValidationError('bla')),
+        iter_errors=mocker.Mock(
+            return_value=[
+                mocker.Mock(
+                    context=[],
+                    absolute_schema_path=['a', 'b'],
+                    absolute_path=['c', 'd'],
+                    message='foobar'
+                )
+            ]
+        )
+    )
+    mocker.patch('jsonschema.Draft4Validator', return_value=validator_mock)
+
+    validator = SchemaValidator()
+
+    with pytest.raises(SchemaValidationError):
+        validator.validate({}, "foo.json")
+
+    logger.info.assert_has_calls([
+        mock.call('╔══════════════════╤═══════════════╤═════════╗'),
+        mock.call('║   schema path    │ instance path │ message ║'),
+        mock.call('╠══════════════════╪═══════════════╪═════════╣'),
+        mock.call("║ schema['a']['b'] │ $['c']['d']   │ foobar  ║"),
+        mock.call('╚══════════════════╧═══════════════╧═════════╝')
+    ])
 
 
 def test_load_schemas_non_existing_schema_file(schema_validator, monkeypatch,

--- a/tests.py
+++ b/tests.py
@@ -40,7 +40,7 @@ def test_validation_error_log(mocker, tmpdir):
     mocker.patch.object(SchemaValidator, '_load_strictness_schema')
     mocker.patch.object(SchemaValidator, 'get_schema',
                         mocker.Mock(return_value={}))
-    logger = mocker.patch('schemavalidator.util.logger',
+    logger = mocker.patch('schemavalidator.schemavalidator.logger',
                           info=mocker.Mock())
     validator_mock = mocker.Mock(
         validate=mocker.Mock(side_effect=ValidationError('bla')),
@@ -62,9 +62,8 @@ def test_validation_error_log(mocker, tmpdir):
     with pytest.raises(SchemaValidationError):
         validator.validate({}, "foo.json")
 
-    logger.log.assert_has_calls([
-        mock.call(logging.DEBUG,
-                  "\n╔══════════════════╤═══════════════╤═════════╗"
+    logger.debug.assert_has_calls([
+        mock.call("\n╔══════════════════╤═══════════════╤═════════╗"
                   "\n║   schema path    │ instance path │ message ║"
                   "\n╠══════════════════╪═══════════════╪═════════╣"
                   "\n║ schema['a']['b'] │ $['c']['d']   │ foobar  ║"
@@ -77,7 +76,7 @@ def test_validation_error_log_empty_paths(mocker, tmpdir):
     mocker.patch.object(SchemaValidator, '_load_strictness_schema')
     mocker.patch.object(SchemaValidator, 'get_schema',
                         mocker.Mock(return_value={}))
-    logger = mocker.patch('schemavalidator.util.logger',
+    logger = mocker.patch('schemavalidator.schemavalidator.logger',
                           info=mocker.Mock())
     validator_mock = mocker.Mock(
         validate=mocker.Mock(side_effect=ValidationError('bla')),
@@ -99,9 +98,8 @@ def test_validation_error_log_empty_paths(mocker, tmpdir):
     with pytest.raises(SchemaValidationError):
         validator.validate({}, "foo.json")
 
-    logger.log.assert_has_calls([
-        mock.call(logging.DEBUG,
-                  '\n╔═════════════╤═══════════════╤═════════╗'
+    logger.debug.assert_has_calls([
+        mock.call('\n╔═════════════╤═══════════════╤═════════╗'
                   '\n║ schema path │ instance path │ message ║'
                   '\n╠═════════════╪═══════════════╪═════════╣'
                   '\n║ schema      │ $             │ foobar  ║'


### PR DESCRIPTION
on a ValidationError a table with possible causes gets dumped to
logging.info. it looks like this:

```
INFO:schemavalidator.schemavalidator:╔═══════════════════════════════════════════════════════════╤═══════════════╤═══════════════════════════════════════════════════════════╗
INFO:schemavalidator.schemavalidator:║                        schema path                        │ instance path │                          message                          ║
INFO:schemavalidator.schemavalidator:╠═══════════════════════════════════════════════════════════╪═══════════════╪═══════════════════════════════════════════════════════════╣
INFO:schemavalidator.schemavalidator:║ schema['properties']['name']['anyOf']                     │ $['name']     │ ['a', 2, 'c'] is not valid under any of the given schemas ║
INFO:schemavalidator.schemavalidator:║ schema['properties']['name']['anyOf'][0]['type']          │ $['name']     │ ['a', 2, 'c'] is not of type 'string'                     ║
INFO:schemavalidator.schemavalidator:║ schema['properties']['name']['anyOf'][1]['items']['type'] │ $['name'][1]  │ 2 is not of type 'string'                                 ║
INFO:schemavalidator.schemavalidator:╚═══════════════════════════════════════════════════════════╧═══════════════╧═══════════════════════════════════════════════════════════╝
```
