### PR TITLE
Improve error sorting with heuristics

### DIFF
--- a/schemavalidator/schemavalidator.py
+++ b/schemavalidator/schemavalidator.py
@@ -4,14 +4,11 @@ import json
 from json import JSONDecodeError
 
 import os
-import logging
 
 import jsonschema
 from jsonschema.exceptions import ValidationError
 import requests
-from .util import format_error_table
-
-logger = logging.getLogger(__name__)
+from .util import log_error_table
 
 
 class SchemaValidatorError(Exception):
@@ -132,7 +129,7 @@ class SchemaValidator(object):
         try:
             validator.validate(document, schema)
         except ValidationError as e:
-            logger.debug(format_error_table(validator, document, schema))
+            log_error_table(validator, document, schema)
             raise SchemaValidationError(e.message) from e
 
     def validate_json_string(self, json_string, schema_id):

--- a/schemavalidator/util.py
+++ b/schemavalidator/util.py
@@ -1,10 +1,21 @@
-def format_error_table(validator, document, schema):
+import logging
+import copy
+
+from jsonschema.exceptions import by_relevance
+
+import schemavalidator
+
+logger = logging.getLogger(schemavalidator.__name__)
+
+def log_error_table(validator, document, schema):
     errors = collect_errors(validator, document, schema)
+    if len(errors)>0:
+        logger.error(errors[0])
     table = errors_to_table(errors)
     if len(table) > 0:
-        return format_table(table, ['schema path', 'instance path', 'message'])
+        logger.debug(format_table(table, ['schema path', 'instance path', 'message']))
     else:
-        return "No additional info available."
+        logger.debug("No additional info available.")
 
 
 def errors_to_table(errors):
@@ -24,13 +35,51 @@ def format_path(path, prefix="$"):
 
 
 def collect_errors(validator, document, schema):
+    field_scores = {
+        'type': 3
+    }
+    validator_scores = {
+        'enum': 2
+    }
+    validator_scores_nonprop = {
+        'anyOf': 1
+    }
     todo = list(validator.iter_errors(document, schema))
     errors = []
     while todo:
         error = todo.pop()
         errors.append(error)
         todo.extend(error.context)
-    errors.sort(key=lambda e: e.absolute_schema_path)
+    scores = {}
+    for error in errors:
+        score = 0       # propagating score, affects neighbors.
+        error.score = 0 # nonpropagating score
+        if len(error.absolute_path) > 0 and len(error.absolute_schema_path) > 0:
+            if error.absolute_path[-1] in field_scores:
+                score += field_scores[error.absolute_path[-1]]
+            if error.absolute_schema_path[-1] in validator_scores:
+                score += validator_scores[error.absolute_schema_path[-1]]
+            if error.absolute_schema_path[-1] in validator_scores_nonprop:
+                error.score += validator_scores_nonprop[error.absolute_schema_path[-1]]
+
+        schema_path = copy.copy(error.absolute_schema_path)
+        while schema_path:
+            path_string = format_path(schema_path)
+            if path_string not in scores:
+                scores[path_string] = 0
+            scores[path_string] += score
+            schema_path.pop()
+
+    for error in errors:
+        path_todo = copy.copy(error.absolute_schema_path)
+        path = []
+        while len(path_todo):
+            path.append(path_todo.popleft())
+            path_string = format_path(path)
+            if path_string in scores:
+                error.score += scores[path_string]
+
+    errors.sort(key=lambda e: e.score)
     return errors
 
 

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import namedtuple,deque
 import logging
 import sys
 
@@ -40,7 +40,7 @@ def test_validation_error_log(mocker, tmpdir):
     mocker.patch.object(SchemaValidator, '_load_strictness_schema')
     mocker.patch.object(SchemaValidator, 'get_schema',
                         mocker.Mock(return_value={}))
-    logger = mocker.patch('schemavalidator.schemavalidator.logger',
+    logger = mocker.patch('schemavalidator.util.logger',
                           info=mocker.Mock())
     validator_mock = mocker.Mock(
         validate=mocker.Mock(side_effect=ValidationError('bla')),
@@ -48,8 +48,8 @@ def test_validation_error_log(mocker, tmpdir):
             return_value=[
                 mocker.Mock(
                     context=[],
-                    absolute_schema_path=['a', 'b'],
-                    absolute_path=['c', 'd'],
+                    absolute_schema_path=deque(['a', 'b']),
+                    absolute_path=deque(['c', 'd']),
                     message='foobar'
                 )
             ]
@@ -76,7 +76,7 @@ def test_validation_error_log_empty_paths(mocker, tmpdir):
     mocker.patch.object(SchemaValidator, '_load_strictness_schema')
     mocker.patch.object(SchemaValidator, 'get_schema',
                         mocker.Mock(return_value={}))
-    logger = mocker.patch('schemavalidator.schemavalidator.logger',
+    logger = mocker.patch('schemavalidator.util.logger',
                           info=mocker.Mock())
     validator_mock = mocker.Mock(
         validate=mocker.Mock(side_effect=ValidationError('bla')),


### PR DESCRIPTION
Sort errors based on some simple heuristics. errors related to anyOf are now more likely to return the most relevant error at the top.
